### PR TITLE
Added support for HTTP Basic Auth for Neo4J connection

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -60,6 +60,10 @@ func (neo4j *Neo4j) doRequest(requestType, url, data string) (string, error) {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 
+	if (neo4j.BasicAuthUser != "") && (neo4j.BasicAuthPassword != "") {
+		req.SetBasicAuth(neo4j.BasicAuthUser, neo4j.BasicAuthPassword)
+	}
+
 	// send request
 	res, err := neo4j.Client.Do(req)
 	if err != nil {
@@ -112,6 +116,10 @@ func (neo4j *Neo4j) doBatchRequest(requestType, url, data string) (string, error
 
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
+
+	if (neo4j.BasicAuthUser != "") && (neo4j.BasicAuthPassword != "") {
+		req.SetBasicAuth(neo4j.BasicAuthUser, neo4j.BasicAuthPassword)
+	}
 
 	res, err := neo4j.Client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Added support for HTTP Basic Auth. pretty standard. I tested locally to make sure it works with neo4j 2.x. Of course you'd have to enable HTTP basic auth on the Neo4J server in order for this to work.
